### PR TITLE
Add reusable k8s pr workflow

### DIFF
--- a/.github/workflows/r-k8s-pr.yaml
+++ b/.github/workflows/r-k8s-pr.yaml
@@ -1,0 +1,161 @@
+on:
+  workflow_call:
+    inputs:
+      overlays_root:
+        description: 'Root overlay directory'
+        required: true
+        type: string
+      enable_flux_diff:
+        description: "Enable flux diff?"
+        required: false
+        type: boolean
+        default: true
+      gke_config_yaml_file:
+        description: "GKE config yaml file relative to overlay (cluster_name, location, project_id)"
+        required: false
+        type: string
+        default: ".gke.yaml"
+      gh_linter_kubeval_options:
+        description: 'Override KUBERNETES_KUBEVAL_OPTIONS on github super linter'
+        required: false
+        type: string
+        default: '--ignore-missing-schemas'
+      gh_linter_validate_all_codebase:
+        description: 'Override VALIDATE_ALL_CODEBASE on github super linter'
+        required: false
+        type: boolean
+        default: false
+      gh_linter_filter_regex_include:
+        description: 'Override FILTER_REGEX_INCLUDE on github super linter'
+        required: false
+        type: string
+        default: '.*'
+      gh_linter_default_branch:
+        description: 'Override default branch for super linter'
+        required: false
+        type: string
+        default: ${{ github.event.repository.default_branch }}
+    secrets:
+      gh_linter_github_token:
+        description: 'Override GITHUB_TOKEN used for super linter'
+        required: false
+      gcp_workload_identity_provider:
+        description: 'Workload identity provider used to authenticate to GCP; EG projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+        required: false
+      gcp_service_account:
+        description: 'Service account used to authenticate to GCP; required if gcp_workload_identity_provider is set'
+        required: false
+      gcp_credentials_json:
+        description: 'Service account JSON key used to authenticate to GCP (Recommended to use workload identity instead)'
+        required: false
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint Code Base
+        uses: github/super-linter@v4.9.0
+        env:
+          VALIDATE_ALL_CODEBASE: ${{ inputs.gh_linter_validate_all_codebase }}
+          FILTER_REGEX_INCLUDE: ${{ inputs.gh_linter_filter_regex_include }}
+          DEFAULT_BRANCH: ${{ inputs.gh_linter_default_branch }}
+          GITHUB_TOKEN: ${{ secrets.gh_linter_github_token || secrets.GITHUB_TOKEN }}
+          KUBERNETES_KUBEVAL_OPTIONS: ${{ inputs.gh_linter_kubeval_options }}
+  overlays:
+    name: Compute overlays
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.result }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get all subfolder overlays
+        id: matrix
+        run: echo "::set-output name=result::$(ls -d -- ${{inputs.overlays_root}}/*/)"
+  k8s-checks:
+    name: K8s Checks
+    runs-on: ubuntu-latest
+    needs: overlays
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.overlays.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get all dependent resources
+        id: dependent-files
+        run: echo "::set-output name=result::$(for r in $(yq '.resources[]' ${{ matrix.plans }}/kustomization.yaml); do realpath --relative-to . ${{matrix.plans}}/$r; done)"
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v24
+        with:
+          files: |
+            ${{ matrix.plans }}
+            ${{ steps.dependent-files.outputs.result }}
+      - uses: imranismail/setup-kustomize@v1
+        if: steps.changed-files.outputs.any_changed == 'true'
+      - name: kustomize build ${{ matrix.plans }}
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: kustomize build ${{ matrix.plans }}
+      - name: Setup yq
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        uses: mikefarah/yq@v4.25.3
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          workload_identity_provider: ${{ secrets.gcp_workload_identity_provider || null }}
+          service_account: ${{ secrets.gcp_service_account || null }}
+          credentials_json: ${{ secrets.gcp_credentials_json || null }}
+      - name: Parse gke config
+        id: gke
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "::set-output name=cluster_name::$(yq .cluster_name ${{ matrix.plans }}/${{ inputs.gke_config_yaml_file }})"
+          echo "::set-output name=location::$(yq .location ${{ matrix.plans }}/${{ inputs.gke_config_yaml_file }})"
+          echo "::set-output name=project_id::$(yq .project_id ${{ matrix.plans }}/${{ inputs.gke_config_yaml_file }})"
+      - name: Setup kubectl
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        uses: 'google-github-actions/get-gke-credentials@v0'
+        with:
+          cluster_name: ${{ steps.gke.outputs.cluster_name }}
+          location: ${{ steps.gke.outputs.location }}
+          project_id: ${{ steps.gke.outputs.project_id }}
+      - name: Setup Flux CLI
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        uses: fluxcd/flux2/action@main
+      - name: flux diff kustomize ${{ matrix.plans }}
+        id: flux-diff
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          NAMESPACE=$(kustomize build ${{ matrix.plans }} | yq -N '. | select(.kind == "Deployment") | .metadata.namespace'|sort -u)
+          flux diff kustomization --namespace $NAMESPACE $NAMESPACE --path ${{ matrix.plans }} 2>&1 | tee diff-msg
+          echo "::set-output name=exit-code::${PIPESTATUS[0]}"
+        continue-on-error: true
+      - id: get-comment-body
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure'
+        run: |
+          body="$(cat diff-msg)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
+      - name: Comment on diff
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure'
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            Flux diff found against cluster for **${{ matrix.plans }}**:
+            ```
+            ${{ steps.get-comment-body.outputs.body }}
+            ```
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check on failures
+        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          if [ "${{ steps.flux-diff.outputs.exit-code }}" -gt "1" ];
+          then
+            echo "error on step flux diff kustomize ${{ matrix.plans }} above"
+            exit 1
+          fi

--- a/.github/workflows/r-k8s-pr.yaml
+++ b/.github/workflows/r-k8s-pr.yaml
@@ -72,7 +72,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get all subfolder overlays
         id: matrix
-        run: echo "::set-output name=result::$(ls -d -- ${{inputs.overlays_root}}/*/)"
+        run: |
+          overlays=$(ls -d -- ${{ inputs.overlays_root }}/*)
+          json=$(jq -n -c --arg overlay "$overlays" '{ overlay: $overlay | split("\n") }')
+          echo "::set-output name=result::$json"
   k8s-checks:
     name: K8s Checks
     runs-on: ubuntu-latest
@@ -84,19 +87,19 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get all dependent resources
         id: dependent-files
-        run: echo "::set-output name=result::$(for r in $(yq '.resources[]' ${{ matrix.plans }}/kustomization.yaml); do realpath --relative-to . ${{matrix.plans}}/$r; done)"
+        run: echo "::set-output name=result::$(for r in $(yq '.resources[]' ${{ matrix.overlay }}/kustomization.yaml); do realpath --relative-to . ${{matrix.overlay}}/$r; done)"
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v24
         with:
           files: |
-            ${{ matrix.plans }}
+            ${{ matrix.overlay }}
             ${{ steps.dependent-files.outputs.result }}
       - uses: imranismail/setup-kustomize@v1
         if: steps.changed-files.outputs.any_changed == 'true'
-      - name: kustomize build ${{ matrix.plans }}
+      - name: kustomize build ${{ matrix.overlay }}
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: kustomize build ${{ matrix.plans }}
+        run: kustomize build ${{ matrix.overlay }}
       - name: Setup yq
         if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
         uses: mikefarah/yq@v4.25.3
@@ -112,9 +115,9 @@ jobs:
         id: gke
         if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
         run: |
-          echo "::set-output name=cluster_name::$(yq .cluster_name ${{ matrix.plans }}/${{ inputs.gke_config_yaml_file }})"
-          echo "::set-output name=location::$(yq .location ${{ matrix.plans }}/${{ inputs.gke_config_yaml_file }})"
-          echo "::set-output name=project_id::$(yq .project_id ${{ matrix.plans }}/${{ inputs.gke_config_yaml_file }})"
+          echo "::set-output name=cluster_name::$(yq .cluster_name ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
+          echo "::set-output name=location::$(yq .location ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
+          echo "::set-output name=project_id::$(yq .project_id ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
       - name: Setup kubectl
         if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
         uses: 'google-github-actions/get-gke-credentials@v0'
@@ -125,12 +128,12 @@ jobs:
       - name: Setup Flux CLI
         if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
         uses: fluxcd/flux2/action@main
-      - name: flux diff kustomize ${{ matrix.plans }}
+      - name: flux diff kustomize ${{ matrix.overlay }}
         id: flux-diff
         if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
         run: |
-          NAMESPACE=$(kustomize build ${{ matrix.plans }} | yq -N '. | select(.kind == "Deployment") | .metadata.namespace'|sort -u)
-          flux diff kustomization --namespace $NAMESPACE $NAMESPACE --path ${{ matrix.plans }} 2>&1 | tee diff-msg
+          NAMESPACE=$(kustomize build ${{ matrix.overlay }} | yq -N '. | select(.kind == "Deployment") | .metadata.namespace'|sort -u)
+          flux diff kustomization --namespace $NAMESPACE $NAMESPACE --path ${{ matrix.overlay }} 2>&1 | tee diff-msg
           echo "::set-output name=exit-code::${PIPESTATUS[0]}"
         continue-on-error: true
       - id: get-comment-body
@@ -146,7 +149,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Flux diff found against cluster for **${{ matrix.plans }}**:
+            Flux diff found against cluster for **${{ matrix.overlay }}**:
             ```
             ${{ steps.get-comment-body.outputs.body }}
             ```
@@ -156,6 +159,6 @@ jobs:
         run: |
           if [ "${{ steps.flux-diff.outputs.exit-code }}" -gt "1" ];
           then
-            echo "error on step flux diff kustomize ${{ matrix.plans }} above"
+            echo "error on step flux diff kustomize ${{ matrix.overlay }} above"
             exit 1
           fi

--- a/.github/workflows/r-k8s-pr.yaml
+++ b/.github/workflows/r-k8s-pr.yaml
@@ -101,11 +101,11 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: kustomize build ${{ matrix.overlay }}
       - name: Setup yq
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' }}
         uses: mikefarah/yq@v4.25.3
       - name: Authenticate to Google Cloud
         id: gcp-auth
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' }}
         uses: 'google-github-actions/auth@v0'
         with:
           workload_identity_provider: ${{ secrets.gcp_workload_identity_provider || null }}
@@ -113,31 +113,31 @@ jobs:
           credentials_json: ${{ secrets.gcp_credentials_json || null }}
       - name: Parse gke config
         id: gke
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           echo "::set-output name=cluster_name::$(yq .cluster_name ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
           echo "::set-output name=location::$(yq .location ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
           echo "::set-output name=project_id::$(yq .project_id ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
       - name: Setup kubectl
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' }}
         uses: 'google-github-actions/get-gke-credentials@v0'
         with:
           cluster_name: ${{ steps.gke.outputs.cluster_name }}
           location: ${{ steps.gke.outputs.location }}
           project_id: ${{ steps.gke.outputs.project_id }}
       - name: Setup Flux CLI
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' }}
         uses: fluxcd/flux2/action@main
       - name: flux diff kustomize ${{ matrix.overlay }}
         id: flux-diff
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           NAMESPACE=$(kustomize build ${{ matrix.overlay }} | yq -N '. | select(.kind == "Deployment") | .metadata.namespace'|sort -u)
           flux diff kustomization --namespace $NAMESPACE $NAMESPACE --path ${{ matrix.overlay }} 2>&1 | tee diff-msg
           echo "::set-output name=exit-code::${PIPESTATUS[0]}"
         continue-on-error: true
       - id: get-comment-body
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
         run: |
           body="$(cat diff-msg)"
           body="${body//'%'/'%25'}"
@@ -145,7 +145,7 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
       - name: Comment on diff
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
@@ -155,7 +155,7 @@ jobs:
             ```
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check on failures
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           if [ "${{ steps.flux-diff.outputs.exit-code }}" -gt "1" ];
           then

--- a/.github/workflows/r-k8s-pr.yaml
+++ b/.github/workflows/r-k8s-pr.yaml
@@ -137,7 +137,7 @@ jobs:
           echo "::set-output name=exit-code::${PIPESTATUS[0]}"
         continue-on-error: true
       - id: get-comment-body
-        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outputs.exit-code >= 1 }}
         run: |
           body="$(cat diff-msg)"
           body="${body//'%'/'%25'}"
@@ -145,7 +145,7 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
       - name: Comment on diff
-        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
+        if: ${{ inputs.enable_flux_diff && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outputs.exit-code >= 1 }}
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |

--- a/.github/workflows/r-k8s-pr.yaml
+++ b/.github/workflows/r-k8s-pr.yaml
@@ -101,11 +101,11 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: kustomize build ${{ matrix.overlay }}
       - name: Setup yq
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
         uses: mikefarah/yq@v4.25.3
       - name: Authenticate to Google Cloud
         id: gcp-auth
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
         uses: 'google-github-actions/auth@v0'
         with:
           workload_identity_provider: ${{ secrets.gcp_workload_identity_provider || null }}
@@ -113,31 +113,31 @@ jobs:
           credentials_json: ${{ secrets.gcp_credentials_json || null }}
       - name: Parse gke config
         id: gke
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           echo "::set-output name=cluster_name::$(yq .cluster_name ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
           echo "::set-output name=location::$(yq .location ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
           echo "::set-output name=project_id::$(yq .project_id ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
       - name: Setup kubectl
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
         uses: 'google-github-actions/get-gke-credentials@v0'
         with:
           cluster_name: ${{ steps.gke.outputs.cluster_name }}
           location: ${{ steps.gke.outputs.location }}
           project_id: ${{ steps.gke.outputs.project_id }}
       - name: Setup Flux CLI
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
         uses: fluxcd/flux2/action@main
       - name: flux diff kustomize ${{ matrix.overlay }}
         id: flux-diff
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           NAMESPACE=$(kustomize build ${{ matrix.overlay }} | yq -N '. | select(.kind == "Deployment") | .metadata.namespace'|sort -u)
           flux diff kustomization --namespace $NAMESPACE $NAMESPACE --path ${{ matrix.overlay }} 2>&1 | tee diff-msg
           echo "::set-output name=exit-code::${PIPESTATUS[0]}"
         continue-on-error: true
       - id: get-comment-body
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
         run: |
           body="$(cat diff-msg)"
           body="${body//'%'/'%25'}"
@@ -145,7 +145,7 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
       - name: Comment on diff
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
@@ -155,7 +155,7 @@ jobs:
             ```
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check on failures
-        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           if [ "${{ steps.flux-diff.outputs.exit-code }}" -gt "1" ];
           then

--- a/.github/workflows/r-k8s-pr.yaml
+++ b/.github/workflows/r-k8s-pr.yaml
@@ -77,7 +77,7 @@ jobs:
           json=$(jq -n -c --arg overlay "$overlays" '{ overlay: $overlay | split("\n") }')
           echo "::set-output name=result::$json"
   k8s-checks:
-    name: K8s Checks
+    name: k8s checks
     runs-on: ubuntu-latest
     needs: overlays
     strategy:
@@ -101,11 +101,11 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: kustomize build ${{ matrix.overlay }}
       - name: Setup yq
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
         uses: mikefarah/yq@v4.25.3
       - name: Authenticate to Google Cloud
         id: gcp-auth
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
         uses: 'google-github-actions/auth@v0'
         with:
           workload_identity_provider: ${{ secrets.gcp_workload_identity_provider || null }}
@@ -113,31 +113,31 @@ jobs:
           credentials_json: ${{ secrets.gcp_credentials_json || null }}
       - name: Parse gke config
         id: gke
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           echo "::set-output name=cluster_name::$(yq .cluster_name ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
           echo "::set-output name=location::$(yq .location ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
           echo "::set-output name=project_id::$(yq .project_id ${{ matrix.overlay }}/${{ inputs.gke_config_yaml_file }})"
       - name: Setup kubectl
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
         uses: 'google-github-actions/get-gke-credentials@v0'
         with:
           cluster_name: ${{ steps.gke.outputs.cluster_name }}
           location: ${{ steps.gke.outputs.location }}
           project_id: ${{ steps.gke.outputs.project_id }}
       - name: Setup Flux CLI
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
         uses: fluxcd/flux2/action@main
       - name: flux diff kustomize ${{ matrix.overlay }}
         id: flux-diff
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           NAMESPACE=$(kustomize build ${{ matrix.overlay }} | yq -N '. | select(.kind == "Deployment") | .metadata.namespace'|sort -u)
           flux diff kustomization --namespace $NAMESPACE $NAMESPACE --path ${{ matrix.overlay }} 2>&1 | tee diff-msg
           echo "::set-output name=exit-code::${PIPESTATUS[0]}"
         continue-on-error: true
       - id: get-comment-body
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
         run: |
           body="$(cat diff-msg)"
           body="${body//'%'/'%25'}"
@@ -145,7 +145,7 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
       - name: Comment on diff
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
@@ -155,7 +155,7 @@ jobs:
             ```
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check on failures
-        if: inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ inputs.enable_flux_diff == 'true' && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           if [ "${{ steps.flux-diff.outputs.exit-code }}" -gt "1" ];
           then

--- a/.github/workflows/r-k8s-pr.yaml
+++ b/.github/workflows/r-k8s-pr.yaml
@@ -137,7 +137,7 @@ jobs:
           echo "::set-output name=exit-code::${PIPESTATUS[0]}"
         continue-on-error: true
       - id: get-comment-body
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
         run: |
           body="$(cat diff-msg)"
           body="${body//'%'/'%25'}"
@@ -145,7 +145,7 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
       - name: Comment on diff
-        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && failure() && steps.flux-diff.conclusion == 'failure' }}
+        if: ${{ inputs.enable_flux_diff == true && steps.changed-files.outputs.any_changed == 'true' && steps.flux-diff.outcome == 'failure' }}
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |


### PR DESCRIPTION
Added:
  * New k8s workflow for PRs


**New k8s workflow**
  * Requires an `overlays_root` directory input
    * For each directory under `overlays_root`
      * kustomize build and flux diff will run by default (Flux diff can be disabled by setting `enable_flux_diff` to `false`) if the overlay or its immediate dependencies have changed
    * If running flux diff, a yaml config file containing GKE cluster_name, location, project_id will need to be present at the root of the overlay, and relevant gcp_* secrets will need to be provided. 